### PR TITLE
Added False checks to ID variables in Cuff and Drag event handlers

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -21,6 +21,10 @@ end)
 
 RegisterServerEvent('SEM_InteractionMenu:CuffNear')
 AddEventHandler('SEM_InteractionMenu:CuffNear', function(ID)
+	if ID == source or ID == false then
+		return
+	end	
+		
 	if ID == -1 or ID == '-1' then
 		if source ~= '' then
 			print('^1[#' .. source .. '] ' .. GetPlayerName(source) .. '  -  attempted to cuff all players^7')
@@ -36,7 +40,7 @@ end)
 
 RegisterServerEvent('SEM_InteractionMenu:DragNear')
 AddEventHandler('SEM_InteractionMenu:DragNear', function(ID)
-	if ID == source then
+	if ID == source or ID == false then
 		return
 	end
 	if ID == -1 or ID == '-1' then


### PR DESCRIPTION
Fixed an issue where if no ID is parsed in /cuff or /drag, the following error would be thrown:
SCRIPT ERROR: Execution of native 000000002f7a49e6 in script host failed: Argument at index 1 was null.