### PR TITLE
Allow mods, trailers, and boats to be spawned in with vehicles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+/.vs

--- a/config.lua
+++ b/config.lua
@@ -280,14 +280,27 @@ Config.LEOVehiclesCategories = {
 	--[[
         EXAMPLE: 
 		['a'] = {
-		    {name = 'b', spawncode = 'c', livery = d, extras = {e, e}},
+		    {name = 'b', spawncode = 'c', livery = d, color = e, extras = {f, f}, mods = {{g,h},{g,h}}, trailer = 'i', trailerlivery = j, trailerextras = {k, k}, boat = 'l', boatlivery = m, boatcolor = n, boatextras = o, boatxoffset = p, boatyoffset = q, boatzoffset = r},
 		}
         ────────────────────────────────────────────────────────────────
         'a' is the title of the Category
         'b' is the title of the vehicle that shows in the menu
         'c' is the spawn code for vehicle that will be spawned
          d  is the number of the livery which you want it to spawn with
-         e  is the number(s) of extra(s) which you want it to spawn with
+         e  is the number of the color which you want it to spawn with (see color list here: https://pastebin.com/pwHci0xK)
+         f  is the number(s) of extra(s) which you want it to spawn with
+         g  is the number(s) of the mod type(s) that you want to set (see mod list here: https://docs.fivem.net/natives/?_0x6AF0636DDEDCB6DD)
+         h  is the number(s) of the mod variation(s) that you want
+        'i'  is the spawn code for trailer
+         j  is the number of the livery which you want the trailer to spawn with
+         k  is the number(s) of extra(s) which you want the trailer to spawn with
+        'l'  is the spawn code for boat (or other vehicle to be carried by the trailer)
+         m  is the number of the livery which you want the boat to spawn with
+         n  is the number of the color which you want the boat to spawn with
+         o  is the number(s) of extra(s) which you want the boat to spawn with
+         p  is the x-axis (left/right) offset of the boat compared to the trailer (required if 'boat' is set)
+         q  is the y-axis (forward/back) offset of the boat compared to the trailer (required if 'boat' is set)
+         r  is the z-axis (up/down) offset of the boat compared to the trailer (required if 'boat' is set)
 
         **NOTE: Sometimes the sections do NOT display if the order in the config below**
     ]]
@@ -305,6 +318,7 @@ Config.LEOVehiclesCategories = {
 
     ['Unmarked'] = {
         {name = 'Unmarked', spawncode = 'police4'},
+        {name = 'Unmarked with boat', spawncode = 'bison', color = 111, mods = {{14,3}, {23,4}}, trailer = 'boattrailer', boat = 'dinghy', boatcolor = 0, boatxoffset = 0, boatyoffset = -1.12, boatzoffset = 0.22}
     },
 }
 
@@ -405,12 +419,25 @@ Config.ShowFireSpawnCode = true
 Config.FireVehicles = {
 	--[[
         EXAMPLE: 
-		{name = 'a', spawncode = 'b', livery = c, extras = {d, d}},
+		{name = 'a', spawncode = 'b', livery = c, color = d, extras = {e, e}, mods = {{f,g},{f,g}}, trailer = 'h', trailerlivery = i, trailerextras = {j, j}, boat = 'k', boatlivery = l, boatcolor = m, boatextras = n, boatxoffset = o, boatyoffset = p, boatzoffset = q},
         ────────────────────────────────────────────────────────────────
         'a' is the title of the vehicle that shows in the menu
         'b' is the spawn code for vehicle that will be spawned
-        'c' is the number of the livery which you want it to spawn with
-        'd'  is the number(s) of extra(s) which you want it to spawn with
+         c  is the number of the livery which you want it to spawn with
+         d  is the number of the color which you want it to spawn with (see color list here: https://pastebin.com/pwHci0xK)
+         e  is the number(s) of extra(s) which you want it to spawn with
+         f  is the number(s) of the mod type(s) that you want to set (see mod list here: https://docs.fivem.net/natives/?_0x6AF0636DDEDCB6DD)
+         g  is the number(s) of the mod variation(s) that you want
+        'h'  is the spawn code for trailer
+         i  is the number of the livery which you want the trailer to spawn with
+         j  is the number(s) of extra(s) which you want the trailer to spawn with
+        'k'  is the spawn code for boat (or other vehicle to be carried by the trailer)
+         l  is the number of the livery which you want the boat to spawn with
+         m  is the number of the color which you want the boat to spawn with
+         n  is the number(s) of extra(s) which you want the boat to spawn with
+         o  is the x-axis (left/right) offset of the boat compared to the trailer (required if 'boat' is set)
+         p  is the y-axis (forward/back) offset of the boat compared to the trailer (required if 'boat' is set)
+         q  is the z-axis (up/down) offset of the boat compared to the trailer (required if 'boat' is set)
 
         **NOTE: Sometimes the sections do NOT display if the order in the config below**
     ]]
@@ -457,15 +484,31 @@ Config.ShowCivSpawnCode = true
 Config.CivVehicles = {
 	--[[
         EXAMPLE: 
-		{name = 'a', spawncode = 'b'},
+		{name = 'a', spawncode = 'b', livery = c, color = d, extras = {e, e}, mods = {{f,g},{f,g}}, trailer = 'h', trailerlivery = i, trailerextras = {j, j}, boat = 'k', boatlivery = l, boatcolor = m, boatextras = n, boatxoffset = o, boatyoffset = p, boatzoffset = q},
         ────────────────────────────────────────────────────────────────
         'a' is the title of the vehicle that shows in the menu
         'b' is the spawn code for vehicle that will be spawned
+         c  is the number of the livery which you want it to spawn with
+         d  is the number of the color which you want it to spawn with (see color list here: https://pastebin.com/pwHci0xK)
+         e  is the number(s) of extra(s) which you want it to spawn with
+         f  is the number(s) of the mod type(s) that you want to set (see mod list here: https://docs.fivem.net/natives/?_0x6AF0636DDEDCB6DD)
+         g  is the number(s) of the mod variation(s) that you want
+        'h'  is the spawn code for trailer
+         i  is the number of the livery which you want the trailer to spawn with
+         j  is the number(s) of extra(s) which you want the trailer to spawn with
+        'k'  is the spawn code for boat (or other vehicle to be carried by the trailer)
+         l  is the number of the livery which you want the boat to spawn with
+         m  is the number of the color which you want the boat to spawn with
+         n  is the number(s) of extra(s) which you want the boat to spawn with
+         o  is the x-axis (left/right) offset of the boat compared to the trailer (required if 'boat' is set)
+         p  is the y-axis (forward/back) offset of the boat compared to the trailer (required if 'boat' is set)
+         q  is the z-axis (up/down) offset of the boat compared to the trailer (required if 'boat' is set)
     ]]
 	
 	--These are the Vehicles that will show in the Category and there spawn codes
 	{name = 'Adder', spawncode = 'adder'},
 	{name = 'Baller', spawncode = 'baller'},
+    {name = 'Transport Truck', spawncode = 'packer', color = 35, trailer = 'trailers3'}
 }
 
 --This determines if the civilian adverts sections of the menu if visible

--- a/functions.lua
+++ b/functions.lua
@@ -181,7 +181,7 @@ end
 
 
 --Vehicle Functions
-function SpawnVehicle(Veh, Name, Livery, Extras)
+function SpawnVehicle(Veh, Name, Livery, Color, Extras, Mods, Trl, TrlLivery, TrlExtras, Bt, BtLivery, BtColor, BtExtras, BtXOffset, BtYOffset, BtZOffset)
     local Ped = GetPlayerPed( -1 )
     if (DoesEntityExist(Ped) and not IsEntityDead(Ped)) then 
         local pos = GetEntityCoords(Ped)
@@ -220,6 +220,9 @@ function SpawnVehicle(Veh, Name, Livery, Extras)
     if Livery then
         SetVehicleLivery(Vehicle, Livery)
     end
+    if Color then
+		SetVehicleColours(Vehicle, Color, Color)
+	end
     if Extras then
         for extraId = 0, 30 do
             if DoesExtraExist(Vehicle, extraId) then
@@ -227,9 +230,102 @@ function SpawnVehicle(Veh, Name, Livery, Extras)
             end
         end
         for _, extra in pairs(Extras) do
-            SetVehicleExtra(Vehicle, extra, false)
+            if DoesExtraExist(Vehicle, extra) then
+                SetVehicleExtra(Vehicle, extra, false)
+            end
         end
     end
+    if Mods then
+        for _, mod in pairs(Mods) do
+            SetVehicleMod(Vehicle, mod[1], mod[2] - 2, false)
+        end
+    end
+
+    if Trl then
+		WaitTime = 0
+		Model = GetHashKey(Trl)
+		RequestModel(Model)
+		while not HasModelLoaded(Model) do
+			CancelEvent()
+			RequestModel(Model)
+			Citizen.Wait(100)
+
+			WaitTime = WaitTime + 1
+
+			if WaitTime == 200 then
+				CancelEvent()
+				Notify('~r~Unable to load trailer, please contact development!')
+				break
+			end
+		end
+		if HasModelLoaded(Model) then
+			local Trailer = CreateVehicle(Model, x, y - 5, z + 1, GetEntityHeading(PlayerPedId()), true, false)
+            SetVehicleDirtLevel(Trailer, 0)
+            SetModelAsNoLongerNeeded(Model)
+			if TrlLivery then
+				SetVehicleLivery(Trailer, TrlLivery)
+			end
+			AttachVehicleToTrailer(Vehicle, Trailer, 1.0)
+
+			if TrlExtras then
+                for extraId = 0, 30 do
+                    if DoesExtraExist(Trailer, extraId) then
+                        SetVehicleExtra(Trailer, extraId, true)
+                    end
+                end
+				for _, extra in pairs(TrlExtras) do
+					if DoesExtraExist(Trailer, extra) then
+						SetVehicleExtra(Trailer, extra, false)
+					end
+				end
+				SetVehicleFixed(Trailer)
+			end
+
+			if Bt then
+				Model = GetHashKey(Bt)
+				RequestModel(Model)
+				while not HasModelLoaded(Model) do
+					CancelEvent()
+					RequestModel(Model)
+					Citizen.Wait(100)
+
+					WaitTime = WaitTime + 1
+
+					if WaitTime == 200 then
+						CancelEvent()
+						Notify('~r~Unable to load boat, please contact development!')
+						break
+					end
+				end
+				if HasModelLoaded(Model) then
+					local Boat = CreateVehicle(Model, x, y - 5, z + 4, GetEntityHeading(PlayerPedId()), true, false)
+                    SetVehicleDirtLevel(Boat, 0)
+                    SetModelAsNoLongerNeeded(Model)
+					if BtLivery then
+						SetVehicleLivery(Boat, BtLivery)
+					end
+					if BtColor then
+						SetVehicleColours(Boat, BtColor, BtColor)
+					end
+					AttachEntityToEntity(Boat, Trailer, 20, BtXOffset, BtYOffset, BtZOffset, 0.0, 0.0, 0.0, false, false, true, false, 20, true)
+
+					if BtExtras then
+						for extraId = 0, 30 do
+                            if DoesExtraExist(Boat, extraId) then
+                                SetVehicleExtra(Boat, extraId, true)
+                            end
+                        end
+				        for _, extra in pairs(TrlExtras) do
+					        if DoesExtraExist(Boat, extra) then
+						        SetVehicleExtra(Boat, extra, false)
+					        end
+				        end
+						SetVehicleFixed(Boat)
+					end
+				end
+			end
+		end
+	end
 
     if Name then
         Notify('~b~Vehicle Spawned: ~g~' .. Name)

--- a/functions.lua
+++ b/functions.lua
@@ -315,7 +315,7 @@ function SpawnVehicle(Veh, Name, Livery, Color, Extras, Mods, Trl, TrlLivery, Tr
                                 SetVehicleExtra(Boat, extraId, true)
                             end
                         end
-				        for _, extra in pairs(TrlExtras) do
+				        for _, extra in pairs(BtExtras) do
 					        if DoesExtraExist(Boat, extra) then
 						        SetVehicleExtra(Boat, extra, false)
 					        end

--- a/menu.lua
+++ b/menu.lua
@@ -399,7 +399,7 @@ function Menu()
                             LEOVehicle:RightLabel(Vehicle.spawncode)
                         end
                         LEOVehicle.Activated = function(ParentMenu, SelectedItem)
-                            SpawnVehicle(Vehicle.spawncode, Vehicle.name, Vehicle.livery, Vehicle.extras)
+                            SpawnVehicle(Vehicle.spawncode, Vehicle.name, Vehicle.livery, Vehicle.color, Vehicle.extras, Vehicle.mods, Vehicle.trailer, Vehicle.trailerlivery, Vehicle.trailerextras, Vehicle.boat, Vehicle.boatlivery, Vehicle.boatcolor, Vehicle.boatextras, Vehicle.boatxoffset, Vehicle.boatyoffset, Vehicle.boatzoffset)
                         end
                     end
                 end
@@ -688,7 +688,7 @@ function Menu()
                         FireVehicle:RightLabel(Vehicle.spawncode)
                     end
                     FireVehicle.Activated = function(ParentMenu, SelectedItem)
-                        SpawnVehicle(Vehicle.spawncode, Vehicle.name, Vehicle.livery, Vehicle.extras)
+                        SpawnVehicle(Vehicle.spawncode, Vehicle.name, Vehicle.livery, Vehicle.color, Vehicle.extras, Vehicle.mods, Vehicle.trailer, Vehicle.trailerlivery, Vehicle.trailerextras, Vehicle.boat, Vehicle.boatlivery, Vehicle.boatcolor, Vehicle.boatextras, Vehicle.boatxoffset, Vehicle.boatyoffset, Vehicle.boatzoffset)
                     end
                 end
             end
@@ -800,7 +800,7 @@ function Menu()
                         CivVehicle:RightLabel(Vehicle.spawncode)
                     end
                     CivVehicle.Activated = function(ParentMenu, SelectedItem)
-                        SpawnVehicle(Vehicle.spawncode, Vehicle.name)
+                        SpawnVehicle(Vehicle.spawncode, Vehicle.name, Vehicle.livery, Vehicle.color, Vehicle.extras, Vehicle.mods, Vehicle.trailer, Vehicle.trailerlivery, Vehicle.trailerextras, Vehicle.boat, Vehicle.boatlivery, Vehicle.boatcolor, Vehicle.boatextras, Vehicle.boatxoffset, Vehicle.boatyoffset, Vehicle.boatzoffset)
                     end
                 end
             end


### PR DESCRIPTION
Enables several new config options for the vehicle spawn menus.  When spawning in a vehicle, you can now configure mods for that vehicle, a trailer (with options, automatically attached to vehicle), and a boat (with options, automatically attached to the trailer).  The configurable 'boat' option can be used to attach other types of vehicles to a trailer as well, such as an ATV.