### PR TITLE
BAC Level error resolved.

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -760,10 +760,14 @@ function Menu()
                     end
 
                     TriggerServerEvent('SEM_InteractionMenu:BACSet', tonumber(BACLevel))
-                    if tonumber(BACLevel) < 0.08 then
-                        Notify('~b~BAC Level Set: ~g~' .. tostring(BACLevel))
+                    if tonumber(BACLevel) ~= nil then
+                      if tonumber(BACLevel) < 0.08 then
+                          Notify('~b~BAC Level Set: ~g~' .. tostring(BACLevel))
+                      else
+                          Notify('~b~BAC Level Set: ~r~' .. tostring(BACLevel))
+                      end
                     else
-                        Notify('~b~BAC Level Set: ~r~' .. tostring(BACLevel))
+                        Notify('~r~Invalid BAC Level!')
                     end
                 end
                 DropWeapon.Activated = function(ParentMenu, SelectedItem)


### PR DESCRIPTION
If you accidentally or mistakenly enter any letters in the text box it returns an error and won't allow you to open the menu again unless restarted or if the player relogs. I resolved the issue by checking if it was nil. Let me know if you have any questions.